### PR TITLE
Fixed typos that ndenny and mariatta suggested

### DIFF
--- a/dining_guide.rst
+++ b/dining_guide.rst
@@ -193,7 +193,7 @@ Short list:
 
 - `Uneeda Burger <http://uneedaburger.com/>`_ All ages, smaller space
 
-- _`PCC community market <https://www.pccmarkets.com/stores/fremont/>`_ All ages, it's really a medium sized grocery store with a deli and a few places to sit.  It is comon to get food at PCC and drinks at Schilling.
+- `PCC community market <https://www.pccmarkets.com/stores/fremont/>`_ All ages, it's really a medium sized grocery store with a deli and a few places to sit.  It is comon to get food at PCC and drinks at Schilling.
 
 
 

--- a/dining_guide.rst
+++ b/dining_guide.rst
@@ -146,7 +146,7 @@ Short list:
 **Downtown Seattle - University Station**
 
 *20-25 minutes via public transit*
-
+https://www.schillingcider.com/home
 The University Station is the next stop on the light rail. It is the closest station to 
 the Seattle Art Museum (SAM) and situated in the business district of Seattle. There are 
 many fast eats that serve the downtown workforce. As well there are bars and evening 
@@ -175,6 +175,26 @@ Bargain Eats
 
 The University is accessible from the I-5, at the 45th St exit. There is some
 parking on campus [to be confirmed]. Prices / availability TBD.
+
+**Fremont**
+
+*25-30 minutes via public transit*
+
+Fremont is something of a nexus of tech companies.  Google, Tableau, Getty Images, Olis Robotics, and adobe (among others) are there.
+I am especially fond of `Schilling Cider <https://www.schillingcider.com/home>`_ which has one of the finest selection of hard ciders in the area [Full disclosure: my daughter works there].  Must be over 21.  Dog friendly.
+
+Short list:
+
+- `Qazi’s Indian Curry House & Mediterranean Cuisine <http://qazisindiancurry.com/`_
+
+- `Nuna Ramen <http://nunaramen.us/>`_ All ages, smaller space
+
+- `Evergreens <https://evergreens.com/`_ All ages, smaller space
+
+- `Uneeda Burger <http://uneedaburger.com/`_ All ages, smaller space
+
+
+
 
 
 

--- a/dining_guide.rst
+++ b/dining_guide.rst
@@ -146,7 +146,7 @@ Short list:
 **Downtown Seattle - University Station**
 
 *20-25 minutes via public transit*
-https://www.schillingcider.com/home
+ 
 The University Station is the next stop on the light rail. It is the closest station to 
 the Seattle Art Museum (SAM) and situated in the business district of Seattle. There are 
 many fast eats that serve the downtown workforce. As well there are bars and evening 
@@ -179,6 +179,8 @@ parking on campus [to be confirmed]. Prices / availability TBD.
 **Fremont**
 
 *25-30 minutes via public transit*
+
++Fremont is something of a nexus of tech companies.  Google, Tableau, Getty Images, Olis Robotics, and Adobe (among others) are there.
 
 I am especially fond of `Schilling Cider <https://www.schillingcider.com/home>`_ which has one of the finest selection of hard ciders in the area [Full disclosure: my daughter works there].  Must be over 21.  Dog friendly.
 

--- a/dining_guide.rst
+++ b/dining_guide.rst
@@ -185,13 +185,17 @@ I am especially fond of `Schilling Cider <https://www.schillingcider.com/home>`_
 
 Short list:
 
-- `Qazi’s Indian Curry House & Mediterranean Cuisine <http://qazisindiancurry.com/`_
+- `Qazi’s Indian Curry House & Mediterranean Cuisine <http://qazisindiancurry.com/>`_
 
 - `Nuna Ramen <http://nunaramen.us/>`_ All ages, smaller space
 
-- `Evergreens <https://evergreens.com/`_ All ages, smaller space
+- `Evergreens <https://evergreens.com/>`_ All ages, smaller space
 
-- `Uneeda Burger <http://uneedaburger.com/`_ All ages, smaller space
+- `Uneeda Burger <http://uneedaburger.com/>`_ All ages, smaller space
+
+- _`PCC community market <https://www.pccmarkets.com/stores/fremont/>`_ All ages, it's really a medium sized grocery store with a deli and a few places to sit.  It is comon to get food at PCC and drinks at Schilling.
+
+
 
 
 

--- a/dining_guide.rst
+++ b/dining_guide.rst
@@ -180,7 +180,6 @@ parking on campus [to be confirmed]. Prices / availability TBD.
 
 *25-30 minutes via public transit*
 
-Fremont is something of a nexus of tech companies.  Google, Tableau, Getty Images, Olis Robotics, and adobe (among others) are there.
 I am especially fond of `Schilling Cider <https://www.schillingcider.com/home>`_ which has one of the finest selection of hard ciders in the area [Full disclosure: my daughter works there].  Must be over 21.  Dog friendly.
 
 Short list:


### PR DESCRIPTION
Mariatta was just suggesting you capitalize the "A" in Adobe, the description is fine otherwise. There's also a stray URL for Schilling Cider on line 149, referenced above that probably shouldn't be there.